### PR TITLE
Declare Kotlin version in Gradle build scripts

### DIFF
--- a/yggdrasil-bootstrap/build.gradle.kts
+++ b/yggdrasil-bootstrap/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
 description = "Bootstrapper for Yggdrasil projects"
 
 plugins {
-  kotlin("jvm")
+  kotlin("jvm") version "1.1.4-3"
 }
 
 dependencies {

--- a/yggdrasil-core/build.gradle.kts
+++ b/yggdrasil-core/build.gradle.kts
@@ -13,7 +13,7 @@ buildscript {
 description = "Yggdrasil core"
 
 plugins {
-  kotlin("jvm")
+  kotlin("jvm") version "1.1.4-3"
 }
 
 dependencies {

--- a/yggdrasil-gradle-plugin/test/build.gradle.kts
+++ b/yggdrasil-gradle-plugin/test/build.gradle.kts
@@ -31,7 +31,7 @@ buildscript {
 }
 
 plugins {
-  kotlin("jvm")
+  kotlin("jvm") version "1.1.4-3"
 }
 
 apply {

--- a/yggdrasil-maven-plugin/build.gradle.kts
+++ b/yggdrasil-maven-plugin/build.gradle.kts
@@ -26,7 +26,7 @@ buildscript {
 description = "Yggdrasil Maven Plugin"
 
 plugins {
-  kotlin("jvm")
+  kotlin("jvm") version "1.1.4-3"
 }
 
 repositories {

--- a/yggdrasil-maven-plugin/test/build.gradle.kts
+++ b/yggdrasil-maven-plugin/test/build.gradle.kts
@@ -32,7 +32,7 @@ buildscript {
 val junitVersion: String = dependencyVersions["junit-platform-gradle-plugin"]!!
 
 plugins {
-  kotlin("jvm")
+  kotlin("jvm") version "1.1.4-3"
 }
 
 apply {


### PR DESCRIPTION
Happy [Gradle 4.3 release](https://github.com/gradle/gradle/releases/tag/v4.3.0) day!

The Gradle team had to make a minor breaking change to the Kotlin DSL, but never fear as this automated pull request should fix the incompatibility by explicitly declaring the Kotlin JVM version in your Kotlin build scripts. See https://github.com/gradle/kotlin-dsl/releases/tag/v0.12.0.

Have a pleasant day! ☀️